### PR TITLE
Fix error handling for failed http fetches

### DIFF
--- a/src/lib/utils/functions.ts
+++ b/src/lib/utils/functions.ts
@@ -192,14 +192,13 @@ export async function getTokenUriType(tokenUri: string): Promise<string> {
     const metadataStr = atob(cleanBase64(tokenUri))
 
     try {
-      /*const metadata = */JSON.parse(metadataStr)
+      JSON.parse(metadataStr)
       return 'embedded';
     } catch (e) {
       console.error(e)
       return 'other';
     }
   } else {
-    console.log("it is url")
     const [url, uriType/*, urlObj*/] = getResolvableUrl(tokenUri)
     const metadataStr = await getMetadataFromUrl(url)
     try {
@@ -211,7 +210,7 @@ export async function getTokenUriType(tokenUri: string): Promise<string> {
         return 'http';
       }
     } catch (e) {
-      console.error("it is not json")
+      console.error(e)
       return 'other';
     }
   }

--- a/src/lib/utils/functions.ts
+++ b/src/lib/utils/functions.ts
@@ -108,7 +108,7 @@ export async function evaluateNft(tokenUri) {
     try {
       metadataStr = await getMetadataFromUrl(url)
     } catch (e) {
-      console.log(e)
+      console.error(e)
       return new NftEvaluation(Math.min(uriGrade, Grade.Unknown), Grade.Unknown, uriType, ImageLocation.MetadataError, null)
     }
 


### PR DESCRIPTION
Adds error handling when HTTP fetches fail. Here is an example of a previously broken one:
<img width="286" alt="Screen Shot 2022-01-28 at 13 43 46" src="https://user-images.githubusercontent.com/714447/151611578-8deae2ec-c66b-4896-9104-073d4b4eaa89.png">

Fixes: https://github.com/ryanlabouve/forever721/issues/37