### PR TITLE
Fix image thumbnails to not break card sizes

### DIFF
--- a/src/lib/nft-thumbnail.svelte
+++ b/src/lib/nft-thumbnail.svelte
@@ -31,7 +31,7 @@
 			{name}
 		</div>
 
-		<img src={image_url} alt={name} class="mx-auto w-32 pb-4" />
+		<img src={image_url} alt={name} class="mx-auto max-w-32 max-h-32 pb-4" />
 
 		<hr />
 


### PR DESCRIPTION
Fixes https://github.com/ryanlabouve/forever721/issues/38
<img width="895" alt="Screen Shot 2022-01-28 at 14 09 12" src="https://user-images.githubusercontent.com/714447/151614576-0950ec27-c1da-40bd-b1af-d9b46aa092dc.png">

